### PR TITLE
fix: update Mars rover API, cam mapping, filtering

### DIFF
--- a/frontend/src/services/nasa-api.ts
+++ b/frontend/src/services/nasa-api.ts
@@ -56,7 +56,7 @@ export class NasaApiService {
 
 	// Mars Rover Photos
 	static async getMarsRoverPhotos(
-		rover: 'curiosity' | 'opportunity' | 'spirit',
+		rover: 'curiosity' | 'perseverance',
 		sol?: number,
 		earthDate?: string,
 		camera?: string,
@@ -78,9 +78,7 @@ export class NasaApiService {
 		return response.data.data;
 	}
 
-	static async getLatestMarsRoverPhotos(
-		rover: 'curiosity' | 'opportunity' | 'spirit'
-	): Promise<{ photos: MarsRoverPhoto[] }> {
+	static async getLatestMarsRoverPhotos(rover: 'curiosity' | 'perseverance'): Promise<{ photos: MarsRoverPhoto[] }> {
 		const response = await backendApi.get<ApiResponse<{ latest_photos: MarsRoverPhoto[] }>>(
 			`/mars-rovers/${rover}/latest-photos`
 		);


### PR DESCRIPTION
- Updates mars rovers being displayed: only active - Curiosity and Perserverance
- Fix filtering: add camera mapping for API<->filtering
- Adjust order based on currently available images
- Fix UI - 2 tabs
- Reset camera selection if it is not available for selected rover